### PR TITLE
Fixed: bail setup script if SVG.supported is false

### DIFF
--- a/src/svg.easing.js
+++ b/src/svg.easing.js
@@ -1,6 +1,10 @@
 // Based on Easing Equations (c) 2003 [Robert Penner](http://www.robertpenner.com/), all rights reserved.
 
 (function() {
+    if (!SVG.supported) {
+        return;
+    }
+
     var easing = {
 
         quadIn: function(pos) {


### PR DESCRIPTION
Fixes an issue where the script will fail because `SVG.easing` is undefined in environments where SVG's are not supported (such as test environments).

Fixes issue #4.